### PR TITLE
fix: upgrade set-function-name to v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	"dependencies": {
 		"call-bind": "^1.0.2",
 		"define-properties": "^1.2.0",
-		"set-function-name": "^2.0.0"
+		"set-function-name": "^2.0.1"
 	},
 	"devDependencies": {
 		"@es-shims/api": "^2.4.2",


### PR DESCRIPTION
There is a bug in `set-function-name` v2.0.0 and we should not use that version.

https://github.com/ljharb/set-function-name/commit/db2eda8da4c8aecfad01739000bbd63d04a8e8cf